### PR TITLE
Return None when the long description is not there

### DIFF
--- a/product.py
+++ b/product.py
@@ -489,8 +489,11 @@ class Product:
         templates.
         """
         if self.use_template_description:
-            return Markup(self.template.description)
-        return Markup(self.description)
+            description = self.template.description
+        else:
+            description = self.description
+        if description:
+            return Markup(description)
 
     def get_product_images(self, name=None):
         """


### PR DESCRIPTION
The long description used a Markup wrapper and it will still show 'None' in text when the long_description is not there. 

```
>>> Markup(None)
Markup(u'None')
```