### PR TITLE
Hiding a separator often used as a reference instead of deleting it.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,9 +94,9 @@ setup(
     },
     package_data={
         'trytond.modules.nereid_catalog':
-            info.get('xml', [])
-            + ['tryton.cfg', 'locale/*.po', 'tests/*.rst', 'view/*.xml']
-            + ['i18n/*.pot', 'i18n/pt_BR/LC_MESSAGES/*'],
+        info.get('xml', []) +
+        ['tryton.cfg', 'locale/*.po', 'tests/*.rst', 'view/*.xml'] +
+        ['i18n/*.pot', 'i18n/pt_BR/LC_MESSAGES/*'],
     },
     license='BSD',
     install_requires=requires,

--- a/view/product_form_nereid.xml
+++ b/view/product_form_nereid.xml
@@ -11,7 +11,8 @@ this repository contains the full copyright notices and license terms. -->
             <field name="use_template_description"/>
     </xpath>
     <xpath expr="/form/separator[@name=&quot;description&quot;]"
-        position="replace">
+        position="replace_attributes">
+	<separator name='description' states="{'invisible': Bool(True)}"/>
     </xpath>
     <xpath expr="/form/field[@name=&quot;description&quot;]"
         position="replace">


### PR DESCRIPTION

The separator of the variant form is quite often referenced as a
reference in other modules. Depending on the sequence they are called in
the chain those modules can not find any more the refrenced tag. So it
is better to hide the tag instead of deleting it.