### PR TITLE
Deprecate boolean fields to use template data

### DIFF
--- a/product.py
+++ b/product.py
@@ -147,11 +147,7 @@ class Product:
 
     displayed_on_eshop = fields.Boolean('Displayed on E-Shop?', select=True)
     long_description = fields.Text('Long Description')
-    media = fields.One2Many(
-        "product.media", "product", "Media", states={
-            'invisible': Bool(Eval('use_template_images'))
-        }, depends=['use_template_images']
-    )
+    media = fields.One2Many("product.media", "product", "Media")
     images = fields.Function(
         fields.One2Many('nereid.static.file', None, 'Images'),
         getter='get_product_images'
@@ -167,6 +163,9 @@ class Product:
     default_image = fields.Function(
         fields.Many2One('nereid.static.file', 'Image'), 'get_default_image',
     )
+
+    # XXX: These fields are left here for legacy reasons. They are
+    # deprecated.
     use_template_description = fields.Boolean("Use template's description")
     use_template_images = fields.Boolean("Use template's images")
 
@@ -203,9 +202,6 @@ class Product:
     @classmethod
     def __setup__(cls):
         super(Product, cls).__setup__()
-        cls.description.states['invisible'] = Bool(
-            Eval('use_template_description')
-        )
         cls._error_messages.update({
             'unique_uri': ('URI of Product must be Unique'),
         })
@@ -235,14 +231,6 @@ class Product:
         if not self.uri and self.template:
             return slugify(self.template.name)
         return self.uri
-
-    @staticmethod
-    def default_use_template_description():
-        return True
-
-    @staticmethod
-    def default_use_template_images():
-        return True
 
     @classmethod
     def check_uri_uniqueness(cls, products):
@@ -464,18 +452,18 @@ class Product:
         """
         Get long description of product.
 
-        If the product is set to use the template's long description, then
-        the template long description is sent back.
+        If the product has a long description, then it is used else
+        the template's long description is used.
 
         The returned value is a `~jinja2.Markup` object which makes it
         HTML safe and can be used directly in templates. It is recommended
         to use this method instead of trying to wrap this logic in the
         templates.
         """
-        if self.use_template_description:
-            description = self.template.long_description
-        else:
+        if self.long_description:
             description = self.long_description
+        else:
+            description = self.template.long_description
 
         return Markup(description or '')
 
@@ -483,18 +471,18 @@ class Product:
         """
         Get description of product.
 
-        If the product is set to use the template's description, then
-        the template description is sent back.
+        If the product has a description, then it is used else
+        the template's description is used.
 
         The returned value is a `~jinja2.Markup` object which makes it
         HTML safe and can be used directly in templates. It is recommended
         to use this method instead of trying to wrap this logic in the
         templates.
         """
-        if self.use_template_description:
-            description = self.template.description
-        else:
+        if self.description:
             description = self.description
+        else:
+            description = self.template.description
         return Markup(description or '')
 
     def get_product_images(self, name=None):
@@ -510,12 +498,13 @@ class Product:
     def get_images(self):
         """
         Get images of product variant.
-        If the product is set to use the template's images, then
-        the template images is sent back.
+
+        If the variant does not have images, then the template's images are
+        sent.
         """
-        if self.use_template_images:
-            return self.template.images
-        return self.images
+        if self.images:
+            return self.images
+        return self.template.images
 
 
 class ProductsRelated(ModelSQL):

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -219,8 +219,8 @@ class TestProduct(NereidTestCase):
     def test0030_get_variant_description(self):
         """
         Test to get variant description.
-        If use_template_description is false, show description
-        of variant else show description of product template
+
+        If there is a variant description get that, if not template's
         """
         with Transaction().start(DB_NAME, USER, context=CONTEXT):
             self.setup_defaults()
@@ -238,11 +238,9 @@ class TestProduct(NereidTestCase):
                 'products': [('create', self.Template.default_products())],
             }])
 
-            # setting use_template_description to false
-            # and adding variant description
+            # adding variant description
             product_variant, = product_template.products
             self.Product.write([product_variant], {
-                'use_template_description': False,
                 'description': 'Description of product',
             })
 
@@ -250,10 +248,11 @@ class TestProduct(NereidTestCase):
                 product_variant.get_description(),
                 'Description of product'
             )
-            # setting use_template_description to true
+
+            # removing variant description
             # description of variant should come from product template
             self.Product.write([product_variant], {
-                'use_template_description': True,
+                'description': None,
             })
 
             self.assertEqual(
@@ -265,8 +264,8 @@ class TestProduct(NereidTestCase):
         """
         Test to get variant images.
 
-        If boolean field use_template_images is true return images
-        of product template else return images of variant
+        If variant has images, then use that. if not return the
+        template's images
         """
         Product = POOL.get('product.product')
         StaticFolder = POOL.get("nereid.static.folder")
@@ -310,17 +309,15 @@ class TestProduct(NereidTestCase):
 
             product, = product_template.products
 
+            # from template
+            self.assertEqual(product.get_images()[0].id, file1.id)
+
             Product.write([product], {
                 'media': [('create', [{
                     'static_file': file1.id,
                 }])]
             })
-
             self.assertEqual(product.get_images()[0].id, file.id)
-            Product.write([product], {
-                'use_template_images': False,
-            })
-            self.assertEqual(product.get_images()[0].id, file1.id)
 
     def test0040_test_uri_uniqueness(self):
         """

--- a/view/product_form_nereid.xml
+++ b/view/product_form_nereid.xml
@@ -7,8 +7,6 @@ this repository contains the full copyright notices and license terms. -->
             <newline/>
             <label name="displayed_on_eshop"/>
             <field name="displayed_on_eshop"/>
-            <label name="use_template_description"/>
-            <field name="use_template_description"/>
     </xpath>
     <xpath expr="/form/separator[@name=&quot;description&quot;]"
         position="replace_attributes">
@@ -32,8 +30,6 @@ this repository contains the full copyright notices and license terms. -->
                 states="{'invisible': Not(Bool(Eval('displayed_on_eshop')))}">
             <label name="uri"/>
             <field name="uri"/>
-            <label name="use_template_images"/>
-            <field name="use_template_images"/>
             <field name="media" colspan="4"/>
         </page>
         <page string="Related Products" col="4" id="related_products"


### PR DESCRIPTION
The fields are kind of redundant since checking if
the value is there in the variant and then using it
or delegating to template is simple (while implicit).

The fields are retained for migration reasons and will
be removed in the next version